### PR TITLE
Reorder linker flag to be after symbol usage

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ selinux:
 	restorecon $(DESTDIR)/usr/bin/getpeercon_server
 
 getpeercon_server: getpeercon_server.c
-	$(CC) $(CFLAGS) -g -o $@ -lselinux $<
+	$(CC) $(CFLAGS) -g -o $@ $< -lselinux 
 
 clean:
 	$(RM) getpeercon_server


### PR DESCRIPTION
This causes a build error on debian based systems

```
$ cc  -g -o getpeercon_server -lselinux getpeercon_server.c
/usr/bin/ld: /tmp/ccxRunfN.o: in function `main':
/home/debian/misc-getpeercon_server/src/getpeercon_server.c:127: undefined reference to `getcon'
/usr/bin/ld: /home/debian/misc-getpeercon_server/src/getpeercon_server.c:207: undefined reference to `getpeercon'
collect2: error: ld returned 1 exit status
$ 
```

```
$ cc  -g -o getpeercon_server getpeercon_server.c -lselinux
$
```

I didn't dig super deep into this, but I'm pretty sure that this is due to gcc or ld evaluating left to right.